### PR TITLE
Enhance: use new features of autocomplete-plus

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -24,6 +24,12 @@ module.exports =
     else
       []
 
+  onDidInsertSuggestion: ({editor, suggestion}) ->
+    setTimeout(@triggerAutocomplete.bind(this, editor), 1) if suggestion.type is 'attribute'
+
+  triggerAutocomplete: (editor) ->
+    atom.commands.dispatch(atom.views.getView(editor), 'autocomplete-plus:activate')
+
   isTagStartWithNoPrefix: ({prefix, scopeDescriptor}) ->
     scopes = scopeDescriptor.getScopesArray()
     prefix is '<' and scopes.length is 1 and scopes[0] is 'text.html.basic'

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -74,38 +74,38 @@ module.exports =
   getAllTagNameCompletions: ->
     completions = []
     for tag, attributes of @completions.tags
-      completions.push({text: tag, replacementPrefix: ''})
+      completions.push({text: tag, type: 'tag'})
     completions
 
   getTagNameCompletions: ({prefix}) ->
     completions = []
     lowerCasePrefix = prefix.toLowerCase()
     for tag, attributes of @completions.tags when tag.indexOf(lowerCasePrefix) is 0
-      completions.push({text: tag, replacementPrefix: prefix})
+      completions.push({text: tag, type: 'tag'})
     completions
 
   getAllAttributeNameCompletions: ({editor, bufferPosition}) ->
     completions = []
 
-    for attribute, options of @completions.attributes
-      completions.push({text: attribute, replacementPrefix: ''}) if options.global
-
     tagAttributes = @getTagAttributes(editor, bufferPosition)
     for attribute in tagAttributes
-      completions.push({text: attribute, replacementPrefix: ''})
+      completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute', rightLabel: 'Tag specific'})
+
+    for attribute, options of @completions.attributes
+      completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute'}) if options.global
 
     completions
 
   getAttributeNameCompletions: ({editor, bufferPosition, prefix}) ->
     completions = []
-
     lowerCasePrefix = prefix.toLowerCase()
-    for attribute, options of @completions.attributes when attribute.indexOf(lowerCasePrefix) is 0
-      completions.push({text: attribute, replacementPrefix: prefix}) if options.global
 
     tagAttributes = @getTagAttributes(editor, bufferPosition)
     for attribute in tagAttributes when attribute.indexOf(lowerCasePrefix) is 0
-      completions.push({text: attribute, replacementPrefix: prefix})
+      completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute', rightLabel: "Tag specific"})
+
+    for attribute, options of @completions.attributes when attribute.indexOf(lowerCasePrefix) is 0
+      completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute'}) if options.global
 
     completions
 
@@ -113,7 +113,7 @@ module.exports =
     completions = []
     values = @getAttributeValues(editor, bufferPosition)
     for value in values
-      completions.push({text: value, replacementPrefix: ''})
+      completions.push({text: value, type: 'value'})
     completions
 
   getAttributeValueCompletions: ({editor, bufferPosition, prefix}) ->
@@ -121,7 +121,7 @@ module.exports =
     values = @getAttributeValues(editor, bufferPosition)
     lowerCasePrefix = prefix.toLowerCase()
     for value in values when value.indexOf(lowerCasePrefix) is 0
-      completions.push({text: value, replacementPrefix: prefix})
+      completions.push({text: value, type: 'value'})
     completions
 
   loadCompletions: ->

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -87,9 +87,10 @@ module.exports =
   getAllAttributeNameCompletions: ({editor, bufferPosition}) ->
     completions = []
 
-    tagAttributes = @getTagAttributes(editor, bufferPosition)
+    tag = @getPreviousTag(editor, bufferPosition)
+    tagAttributes = @getTagAttributes(tag)
     for attribute in tagAttributes
-      completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute', rightLabel: 'Tag specific'})
+      completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute', rightLabel: "<#{tag}>"})
 
     for attribute, options of @completions.attributes
       completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute'}) if options.global
@@ -100,9 +101,10 @@ module.exports =
     completions = []
     lowerCasePrefix = prefix.toLowerCase()
 
-    tagAttributes = @getTagAttributes(editor, bufferPosition)
+    tag = @getPreviousTag(editor, bufferPosition)
+    tagAttributes = @getTagAttributes(tag)
     for attribute in tagAttributes when attribute.indexOf(lowerCasePrefix) is 0
-      completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute', rightLabel: "Tag specific"})
+      completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute', rightLabel: "<#{tag}>"})
 
     for attribute, options of @completions.attributes when attribute.indexOf(lowerCasePrefix) is 0
       completions.push({snippet: "#{attribute}=\"$1\"$0", displayText: attribute, type: 'attribute'}) if options.global
@@ -152,6 +154,5 @@ module.exports =
     attribute = @completions.attributes[@getPreviousAttribute(editor, bufferPosition)]
     attribute?.attribOption ? []
 
-  getTagAttributes: (editor, bufferPosition) ->
-    tag = @getPreviousTag(editor, bufferPosition)
+  getTagAttributes: (tag) ->
     @completions.tags[tag]?.attributes ? []

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -265,3 +265,15 @@ describe "HTML autocompletions", ->
     expect(completions[3].text).toBe 'et'
     expect(completions[4].text).toBe 'el'
     expect(completions[5].text).toBe 'es'
+
+  it "triggers autocomplete when an attibute has been inserted", ->
+    spyOn(atom.commands, 'dispatch')
+    suggestion = {type: 'attribute', text: 'whatever'}
+    provider.onDidInsertSuggestion({editor, suggestion})
+
+    advanceClock 1
+    expect(atom.commands.dispatch).toHaveBeenCalled()
+
+    args = atom.commands.dispatch.mostRecentCall.args
+    expect(args[0].tagName.toLowerCase()).toBe 'atom-text-editor'
+    expect(args[1]).toBe 'autocomplete-plus:activate'

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -61,6 +61,7 @@ describe "HTML autocompletions", ->
 
     for completion in completions
       expect(completion.text.length).toBeGreaterThan 0
+      expect(completion.type).toBe 'tag'
 
   it "autocompletes tag names with a prefix", ->
     editor.setText('<d')
@@ -70,7 +71,7 @@ describe "HTML autocompletions", ->
     expect(completions.length).toBe 9
 
     expect(completions[0].text).toBe 'datalist'
-    expect(completions[0].replacementPrefix).toBe 'd'
+    expect(completions[0].type).toBe 'tag'
     expect(completions[1].text).toBe 'dd'
     expect(completions[2].text).toBe 'del'
     expect(completions[3].text).toBe 'details'
@@ -87,7 +88,7 @@ describe "HTML autocompletions", ->
     expect(completions.length).toBe 9
 
     expect(completions[0].text).toBe 'datalist'
-    expect(completions[0].replacementPrefix).toBe 'D'
+    expect(completions[0].type).toBe 'tag'
     expect(completions[1].text).toBe 'dd'
     expect(completions[2].text).toBe 'del'
     expect(completions[3].text).toBe 'details'
@@ -105,7 +106,9 @@ describe "HTML autocompletions", ->
     expect(completions.length).toBe 69
 
     for completion in completions
-      expect(completion.text.length).toBeGreaterThan 0
+      expect(completion.snippet.length).toBeGreaterThan 0
+      expect(completion.displayText.length).toBeGreaterThan 0
+      expect(completion.type).toBe 'attribute'
 
     editor.setText('<marquee ')
     editor.setCursorBufferPosition([0, 9])
@@ -114,7 +117,9 @@ describe "HTML autocompletions", ->
     expect(completions.length).toBe 81
 
     for completion in completions
-      expect(completion.text.length).toBeGreaterThan 0
+      expect(completion.snippet.length).toBeGreaterThan 0
+      expect(completion.displayText.length).toBeGreaterThan 0
+      expect(completion.type).toBe 'attribute'
 
   it "autocompletes attribute names with a prefix", ->
     editor.setText('<div c')
@@ -123,10 +128,11 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions.length).toBe 3
 
-    expect(completions[0].text).toBe 'class'
-    expect(completions[0].replacementPrefix).toBe 'c'
-    expect(completions[1].text).toBe 'contenteditable'
-    expect(completions[2].text).toBe 'contextmenu'
+    expect(completions[0].snippet).toBe 'class="$0"$1'
+    expect(completions[0].displayText).toBe 'class'
+    expect(completions[0].type).toBe 'attribute'
+    expect(completions[1].displayText).toBe 'contenteditable'
+    expect(completions[2].displayText).toBe 'contextmenu'
 
     editor.setText('<div C')
     editor.setCursorBufferPosition([0, 6])
@@ -134,10 +140,9 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions.length).toBe 3
 
-    expect(completions[0].text).toBe 'class'
-    expect(completions[0].replacementPrefix).toBe 'C'
-    expect(completions[1].text).toBe 'contenteditable'
-    expect(completions[2].text).toBe 'contextmenu'
+    expect(completions[0].displayText).toBe 'class'
+    expect(completions[1].displayText).toBe 'contenteditable'
+    expect(completions[2].displayText).toBe 'contextmenu'
 
     editor.setText('<div c>')
     editor.setCursorBufferPosition([0, 6])
@@ -145,9 +150,9 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions.length).toBe 3
 
-    expect(completions[0].text).toBe 'class'
-    expect(completions[1].text).toBe 'contenteditable'
-    expect(completions[2].text).toBe 'contextmenu'
+    expect(completions[0].displayText).toBe 'class'
+    expect(completions[1].displayText).toBe 'contenteditable'
+    expect(completions[2].displayText).toBe 'contextmenu'
 
     editor.setText('<div c></div>')
     editor.setCursorBufferPosition([0, 6])
@@ -155,9 +160,9 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions.length).toBe 3
 
-    expect(completions[0].text).toBe 'class'
-    expect(completions[1].text).toBe 'contenteditable'
-    expect(completions[2].text).toBe 'contextmenu'
+    expect(completions[0].displayText).toBe 'class'
+    expect(completions[1].displayText).toBe 'contenteditable'
+    expect(completions[2].displayText).toBe 'contextmenu'
 
     editor.setText('<marquee di')
     editor.setCursorBufferPosition([0, 12])
@@ -165,8 +170,8 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions.length).toBe 2
 
-    expect(completions[0].text).toBe 'dir'
-    expect(completions[1].text).toBe 'direction'
+    expect(completions[0].displayText).toBe 'direction'
+    expect(completions[1].displayText).toBe 'dir'
 
     editor.setText('<marquee dI')
     editor.setCursorBufferPosition([0, 12])
@@ -174,8 +179,8 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions.length).toBe 2
 
-    expect(completions[0].text).toBe 'dir'
-    expect(completions[1].text).toBe 'direction'
+    expect(completions[0].displayText).toBe 'direction'
+    expect(completions[1].displayText).toBe 'dir'
 
   it "autocompletes attribute values without a prefix", ->
     editor.setText('<div behavior=""')
@@ -185,6 +190,7 @@ describe "HTML autocompletions", ->
     expect(completions.length).toBe 3
 
     expect(completions[0].text).toBe 'scroll'
+    expect(completions[0].type).toBe 'value'
     expect(completions[1].text).toBe 'slide'
     expect(completions[2].text).toBe 'alternate'
 
@@ -226,7 +232,7 @@ describe "HTML autocompletions", ->
     expect(completions.length).toBe 6
 
     expect(completions[0].text).toBe 'eu'
-    expect(completions[0].replacementPrefix).toBe 'e'
+    expect(completions[0].type).toBe 'value'
     expect(completions[1].text).toBe 'en'
     expect(completions[2].text).toBe 'eo'
     expect(completions[3].text).toBe 'et'
@@ -240,7 +246,6 @@ describe "HTML autocompletions", ->
     expect(completions.length).toBe 6
 
     expect(completions[0].text).toBe 'eu'
-    expect(completions[0].replacementPrefix).toBe 'E'
     expect(completions[1].text).toBe 'en'
     expect(completions[2].text).toBe 'eo'
     expect(completions[3].text).toBe 'et'

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -115,6 +115,7 @@ describe "HTML autocompletions", ->
 
     completions = getCompletions()
     expect(completions.length).toBe 81
+    expect(completions[0].rightLabel).toBe '<marquee>'
 
     for completion in completions
       expect(completion.snippet.length).toBeGreaterThan 0
@@ -128,7 +129,7 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions.length).toBe 3
 
-    expect(completions[0].snippet).toBe 'class="$0"$1'
+    expect(completions[0].snippet).toBe 'class="$1"$0'
     expect(completions[0].displayText).toBe 'class'
     expect(completions[0].type).toBe 'attribute'
     expect(completions[1].displayText).toBe 'contenteditable'


### PR DESCRIPTION
![screen shot 2015-04-20 at 6 27 00 pm](https://cloud.githubusercontent.com/assets/69169/7244078/dd5887ee-e78a-11e4-9f35-bde468e0f994.png)

(If you have a better name for `tag specific` that would be cool)
![screen shot 2015-04-20 at 6 27 51 pm](https://cloud.githubusercontent.com/assets/69169/7244086/fd45352a-e78a-11e4-9a91-07bef694f41c.png)

![screen shot 2015-04-20 at 6 26 45 pm](https://cloud.githubusercontent.com/assets/69169/7244081/e37010f2-e78a-11e4-9777-d0877062ddf9.png)

TODO

* [x] Use the features
* [x] Auto show suggestions after completing an attribute
