### PR TITLE
[WIP] Complete CSS selectors inside of attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "devDependencies": {
     "coffeelint": "^1.9.7",
     "request": "^2.53.0"
+  },
+  "dependencies": {
+    "css": "^2.2.1"
   }
 }

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -283,3 +283,17 @@ describe "HTML autocompletions", ->
     args = atom.commands.dispatch.mostRecentCall.args
     expect(args[0].tagName.toLowerCase()).toBe 'atom-text-editor'
     expect(args[1]).toBe 'autocomplete-plus:activate'
+
+  it "autocompletes class names within same file", ->
+    editor.setText('<style>.test{}</style><div class=""')
+    editor.setCursorBufferPosition([0, 34])
+    completions = getCompletions()
+    expect(completions.length).toBe 1
+    expect(completions[0].text).toBe 'test'
+
+  it "autocompletes ids within same file", ->
+    editor.setText('<style>#test{}</style><div id=""')
+    editor.setCursorBufferPosition([0, 31])
+    completions = getCompletions()
+    expect(completions.length).toBe 1
+    expect(completions[0].text).toBe 'test'


### PR DESCRIPTION
This is work in progress and still requires some modifications, but I would love to hear some feedback before I will continue.

- [ ] Silently eat all CSS parser errors
- [ ] Do not re-build every stylesheets on each keystroke. Need to implement some smart caching here
- [ ] Do not look for stylesheets in directories ignored by Atom
- [ ] Figure out how to write tests with multiple files in project

![sample](https://cloud.githubusercontent.com/assets/193864/12051356/7c597edc-af3d-11e5-9acc-4f18053b7797.gif)

#13