### PR TITLE
Support reading completions.json when loading the package from snapshot

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,6 +1,6 @@
 provider = require './provider'
 
 module.exports =
-  activate: -> provider.loadCompletions()
+  activate: ->
 
   getProvider: -> provider

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -1,5 +1,5 @@
-fs = require 'fs'
 path = require 'path'
+COMPLETIONS = require '../completions.json'
 
 trailingWhitespace = /\s$/
 attributePattern = /\s+([a-zA-Z][-a-zA-Z]*)\s*=\s*$/
@@ -9,6 +9,7 @@ module.exports =
   selector: '.text.html'
   disableForSelector: '.text.html .comment'
   filterSuggestions: true
+  completions: COMPLETIONS
 
   getSuggestions: (request) ->
     {prefix} = request
@@ -143,12 +144,6 @@ module.exports =
       type: 'value'
       description: "#{value} value for #{attribute} attribute local to <#{tag}>"
       descriptionMoreURL: @getLocalAttributeDocsURL(attribute, tag)
-
-  loadCompletions: ->
-    @completions = {}
-    fs.readFile path.resolve(__dirname, '..', 'completions.json'), (error, content) =>
-      @completions = JSON.parse(content) unless error?
-      return
 
   getPreviousTag: (editor, bufferPosition) ->
     {row} = bufferPosition


### PR DESCRIPTION
Refs: https://github.com/atom/atom/pull/13916#issuecomment-286990077

Using `__dirname` inside the snapshot will return a relative path, which will cause this package to fail to load completions from `{packageRoot}/completions.json`. With this pull request we use the `require` system to load such file so that it can be snapshotted; doing so will fix the aforementioned error and will improve performance as well because we will save a file system call.