### PR TITLE
Improve tag and global attribute descriptions

### DIFF
--- a/completions.json
+++ b/completions.json
@@ -1687,6 +1687,15 @@
       "type": "flag"
     },
     "name": {},
+    "meta/name": {
+      "attribOption": [
+        "application-name",
+        "author",
+        "description",
+        "generator",
+        "keywords"
+      ]
+    },
     "novalidate": {
       "type": "flag"
     },
@@ -1722,6 +1731,23 @@
         "sidebar",
         "tag",
         "external"
+      ]
+    },
+    "link/rel": {
+      "attribOption": [
+        "alternate",
+        "author",
+        "help",
+        "icon",
+        "license",
+        "next",
+        "pingback",
+        "prefetch",
+        "prev",
+        "search",
+        "sidebar",
+        "stylesheet",
+        "tag"
       ]
     },
     "readonly": {
@@ -1795,6 +1821,90 @@
       "type": "flag"
     },
     "type": {},
+    "button/type": {
+      "attribOption": [
+        "button",
+        "reset",
+        "submit"
+      ]
+    },
+    "command/type": {
+      "attribOption": [
+        "command",
+        "checkbox",
+        "radio"
+      ]
+    },
+    "link/type": {
+      "attribOption": [
+        "text/css"
+      ]
+    },
+    "menu/type": {
+      "attribOption": [
+        "context",
+        "list",
+        "toolbar"
+      ]
+    },
+    "ol/type": {
+      "attribOption": [
+        "1",
+        "a",
+        "A",
+        "i",
+        "I"
+      ]
+    },
+    "script/type": {
+      "attribOption": [
+        "text/javascript",
+        "text/ecmascript",
+        "text/jscript",
+        "text/livescript",
+        "text/tcl",
+        "text/x-javascript",
+        "text/x-ecmascript",
+        "application/x-javascript",
+        "application/x-ecmascript",
+        "application/javascript",
+        "application/ecmascript",
+        "text/babel",
+        "text/jsx"
+      ]
+    },
+    "style/type": {
+      "attribOption": [
+        "text/css"
+      ]
+    },
+    "input/type": {
+      "attribOption": [
+        "button",
+        "checkbox",
+        "color",
+        "date",
+        "datetime",
+        "datetime-local",
+        "email",
+        "file",
+        "hidden",
+        "image",
+        "month",
+        "number",
+        "password",
+        "radio",
+        "range",
+        "reset",
+        "search",
+        "submit",
+        "tel",
+        "text",
+        "time",
+        "url",
+        "week"
+      ]
+    },
     "usemap": {},
     "value": {},
     "vspace": {},

--- a/completions.json
+++ b/completions.json
@@ -382,7 +382,7 @@
       "description": "Specifies relationships between the current document and an external resource."
     },
     "main": {
-      "description": "Represents the main content of  the body of a document or application."
+      "description": "Represents the main content of the body of a document or application."
     },
     "map": {
       "attributes": [
@@ -596,7 +596,7 @@
       "attributes": [
         "border"
       ],
-      "description": "Represents tabular data —that is, information expressed via a two-dimensional data table."
+      "description": "Represents tabular data — that is, information expressed via a two-dimensional data table."
     },
     "tbody": {
       "description": "Groups one or more tr elements as the body of a table element."
@@ -669,7 +669,7 @@
         "src",
         "srclang"
       ],
-      "description": "Used as a child of the media elements— audio and video."
+      "description": "Used as a child of the media elements audio and video."
     },
     "tt": {
       "description": "The tt element is obsolete. Avoid using it and update existing code if possible."

--- a/completions.json
+++ b/completions.json
@@ -8,10 +8,15 @@
         "rel",
         "target",
         "type"
-      ]
+      ],
+      "description": "Creates a hyperlink to other web pages, files, locations within the same page, email addresses, or any other URL."
     },
-    "abbr": {},
-    "address": {},
+    "abbr": {
+      "description": "Represents an abbreviation and optionally provides a full description for it."
+    },
+    "address": {
+      "description": "Supplies contact information for its nearest article or body ancestor; in the latter case, it applies to the whole document."
+    },
     "area": {
       "attributes": [
         "alt",
@@ -23,10 +28,15 @@
         "shape",
         "target",
         "type"
-      ]
+      ],
+      "description": "Defines a hot-spot region on an image, and optionally associates it with a hypertext link."
     },
-    "article": {},
-    "aside": {},
+    "article": {
+      "description": "Represents a self-contained composition in a document, page, application, or site, which is intended to be independently distributable or reusable (e."
+    },
+    "aside": {
+      "description": "Represents a section of a document with content connected tangentially to the main content of the document (often presented as a sidebar)."
+    },
     "audio": {
       "attributes": [
         "autoplay",
@@ -36,22 +46,33 @@
         "muted",
         "preload",
         "src"
-      ]
+      ],
+      "description": "Used to embed sound content in documents."
     },
-    "b": {},
+    "b": {
+      "description": "Represents a span of text stylistically different from normal text, without conveying any special importance or relevance, and that is typically rendered in boldface."
+    },
     "base": {
       "attributes": [
         "href",
         "target"
-      ]
+      ],
+      "description": "Specifies the base URL to use for all relative URLs contained within a document."
     },
-    "bdi": {},
-    "bdo": {},
-    "big": {},
+    "bdi": {
+      "description": "Isolates a span of text that might be formatted in a different direction from other text outside it."
+    },
+    "bdo": {
+      "description": "Used to override the current directionality of text."
+    },
+    "big": {
+      "description": "The big element is obsolete. Avoid using it and update existing code if possible."
+    },
     "blockquote": {
       "attributes": [
         "cite"
-      ]
+      ],
+      "description": "Indicates that the enclosed text is an extended quotation."
     },
     "body": {
       "attributes": [
@@ -70,9 +91,12 @@
         "onstorage",
         "onundo",
         "onunload"
-      ]
+      ],
+      "description": "Represents the content of an HTML document."
     },
-    "br": {},
+    "br": {
+      "description": "Produces a line break in text (carriage-return)."
+    },
     "button": {
       "attributes": [
         "autofocus",
@@ -86,26 +110,36 @@
         "name",
         "type",
         "value"
-      ]
+      ],
+      "description": "Represents a clickable button."
     },
     "canvas": {
       "attributes": [
         "height",
         "width"
-      ]
+      ],
+      "description": "Use the HTML canvas element with the canvas scripting API to draw graphics and animations."
     },
-    "caption": {},
-    "cite": {},
-    "code": {},
+    "caption": {
+      "description": "Represents the title of a table."
+    },
+    "cite": {
+      "description": "Represents a reference to a creative work."
+    },
+    "code": {
+      "description": "Represents a fragment of computer code."
+    },
     "col": {
       "attributes": [
         "span"
-      ]
+      ],
+      "description": "Defines a column within a table and is used for defining common semantics on all common cells."
     },
     "colgroup": {
       "attributes": [
         "span"
-      ]
+      ],
+      "description": "Defines a group of columns within a table."
     },
     "command": {
       "attributes": [
@@ -115,49 +149,75 @@
         "label",
         "radiogroup",
         "type"
-      ]
+      ],
+      "description": "The command element is obsolete. Avoid using it and update existing code if possible."
     },
-    "datalist": {},
-    "dd": {},
+    "datalist": {
+      "description": "Contains a set of option elements that represent the values available for other controls."
+    },
+    "dd": {
+      "description": "Indicates the description of a term in a description list (dl)."
+    },
     "del": {
       "attributes": [
         "cite",
         "datetime"
-      ]
+      ],
+      "description": "Represents a range of text that has been deleted from a document."
     },
     "details": {
       "attributes": [
         "open"
-      ]
+      ],
+      "description": "Used as a disclosure widget from which the user can retrieve additional information."
     },
-    "dfn": {},
+    "dfn": {
+      "description": "Represents the defining instance of a term."
+    },
     "dialog": {
       "attributes": [
         "open"
-      ]
+      ],
+      "description": "Represents a dialog box or other interactive component, such as an inspector or window."
     },
-    "div": {},
-    "dl": {},
-    "dt": {},
-    "em": {},
+    "div": {
+      "description": "The generic container for flow content and does not inherently represent anything."
+    },
+    "dl": {
+      "description": "Represents a description list."
+    },
+    "dt": {
+      "description": "Identifies a term in a description list."
+    },
+    "em": {
+      "description": "Marks text that has stress emphasis."
+    },
     "embed": {
       "attributes": [
         "height",
         "src",
         "type",
         "width"
-      ]
+      ],
+      "description": "Represents an integration point for an external application or interactive content (in other words, a plug-in)."
     },
     "fieldset": {
       "attributes": [
         "disabled",
         "form",
         "name"
-      ]
+      ],
+      "description": "Used to group several controls as well as labels (label) within a web form."
     },
-    "figcaption": {},
-    "figure": {},
-    "footer": {},
+    "figcaption": {
+      "description": "Represents a caption or a legend associated with a figure or an illustration described by the rest of the data of the figure element which is its immediate ancestor."
+    },
+    "figure": {
+      "description": "Represents self-contained content, frequently with a caption (figcaption), and is typically referenced as a single unit."
+    },
+    "footer": {
+      "description": "Represents a footer for its nearest sectioning content or sectioning root element."
+    },
     "form": {
       "attributes": [
         "accept-charset",
@@ -168,26 +228,50 @@
         "name",
         "novalidate",
         "target"
-      ]
+      ],
+      "description": "Represents a document section that contains interactive controls to submit information to a web server."
     },
-    "h1": {},
-    "h2": {},
-    "h3": {},
-    "h4": {},
-    "h5": {},
-    "h6": {},
-    "head": {},
-    "header": {},
-    "hgroup": {},
-    "hr": {},
+    "h1": {
+      "description": "The HTML h1 – h6 elements represent six levels of section headings."
+    },
+    "h2": {
+      "description": "The HTML h1 – h6 elements represent six levels of section headings."
+    },
+    "h3": {
+      "description": "The HTML h1 – h6 elements represent six levels of section headings."
+    },
+    "h4": {
+      "description": "The HTML h1 – h6 elements represent six levels of section headings."
+    },
+    "h5": {
+      "description": "The HTML h1 – h6 elements represent six levels of section headings."
+    },
+    "h6": {
+      "description": "The HTML h1 – h6 elements represent six levels of section headings."
+    },
+    "head": {
+      "description": "Provides general information (metadata) about the document, including its title and links to its scripts and style sheets."
+    },
+    "header": {
+      "description": "Represents a group of introductory or navigational aids."
+    },
+    "hgroup": {
+      "description": "Represents a multi-level heading for a section of a document."
+    },
+    "hr": {
+      "description": "Represents a thematic break between paragraph-level elements (for example, a change of scene in a story, or a shift of topic with a section)."
+    },
     "html": {
       "attributes": [
         "manifest",
         "xml:lang",
         "xmlns"
-      ]
+      ],
+      "description": "Represents the root (top-level element) of an HTML document, so it is also referred to as the root element."
     },
-    "i": {},
+    "i": {
+      "description": "Represents a range of text that is set off from the normal text for some reason, for example, technical terms, foreign language phrases, or fictional character thoughts."
+    },
     "iframe": {
       "attributes": [
         "height",
@@ -197,7 +281,8 @@
         "src",
         "srcdoc",
         "width"
-      ]
+      ],
+      "description": "Represents a nested browsing context, effectively embedding another HTML page into the current page."
     },
     "ilayer": {},
     "img": {
@@ -209,7 +294,8 @@
         "src",
         "usemap",
         "width"
-      ]
+      ],
+      "description": "Represents an image in the document."
     },
     "input": {
       "attributes": [
@@ -243,15 +329,19 @@
         "type",
         "value",
         "width"
-      ]
+      ],
+      "description": "Used to create interactive controls for web-based forms in order to accept data from the user."
     },
     "ins": {
       "attributes": [
         "cite",
         "datetime"
-      ]
+      ],
+      "description": "Represents a range of text that has been added to a document."
     },
-    "kbd": {},
+    "kbd": {
+      "description": "Represents user input and produces an inline element displayed in the browser's default monospace font."
+    },
     "keygen": {
       "attributes": [
         "autofocus",
@@ -260,19 +350,24 @@
         "form",
         "keytype",
         "name"
-      ]
+      ],
+      "description": "The keygen element is deprecated. Avoid using it and update existing code if possible."
     },
     "label": {
       "attributes": [
         "for",
         "form"
-      ]
+      ],
+      "description": "Represents a caption for an item in a user interface."
     },
-    "legend": {},
+    "legend": {
+      "description": "Represents a caption for the content of its parent fieldset."
+    },
     "li": {
       "attributes": [
         "value"
-      ]
+      ],
+      "description": "Used to represent an item in a list."
     },
     "link": {
       "attributes": [
@@ -283,15 +378,21 @@
         "rel",
         "sizes",
         "type"
-      ]
+      ],
+      "description": "Specifies relationships between the current document and an external resource."
     },
-    "main": {},
+    "main": {
+      "description": "Represents the main content of  the body of a document or application."
+    },
     "map": {
       "attributes": [
         "name"
-      ]
+      ],
+      "description": "Used with area elements to define an image map (a clickable link area)."
     },
-    "mark": {},
+    "mark": {
+      "description": "Represents highlighted text, i."
+    },
     "marquee": {
       "attributes": [
         "align",
@@ -306,13 +407,15 @@
         "truespeed",
         "vspace",
         "width"
-      ]
+      ],
+      "description": "The marquee element is obsolete. Avoid using it and update existing code if possible."
     },
     "menu": {
       "attributes": [
         "label",
         "type"
-      ]
+      ],
+      "description": "Represents a group of commands that a user can perform or activate."
     },
     "meta": {
       "attributes": [
@@ -320,7 +423,8 @@
         "content",
         "http-equiv",
         "name"
-      ]
+      ],
+      "description": "Represents metadata that cannot be represented by other HTML meta-related elements, like base, link, script, style or title."
     },
     "meter": {
       "attributes": [
@@ -331,10 +435,15 @@
         "min",
         "optimum",
         "value"
-      ]
+      ],
+      "description": "Represents either a scalar value within a known range or a fractional value."
     },
-    "nav": {},
-    "noscript": {},
+    "nav": {
+      "description": "Represents a section of a page that links to other pages or to parts within the page: a section with navigation links."
+    },
+    "noscript": {
+      "description": "Defines a section of html to be inserted if a script type on the page is unsupported or if scripting is currently turned off in the browser."
+    },
     "object": {
       "attributes": [
         "archive",
@@ -349,20 +458,23 @@
         "type",
         "usemap",
         "width"
-      ]
+      ],
+      "description": "Represents an external resource, which can be treated as an image, a nested browsing context, or a resource to be handled by a plugin."
     },
     "ol": {
       "attributes": [
         "reversed",
         "start",
         "type"
-      ]
+      ],
+      "description": "Represents an ordered list of items, typically rendered as a numbered list."
     },
     "optgroup": {
       "attributes": [
         "disabled",
         "label"
-      ]
+      ],
+      "description": "Creates a grouping of options within a select element."
     },
     "option": {
       "attributes": [
@@ -370,39 +482,56 @@
         "label",
         "selected",
         "value"
-      ]
+      ],
+      "description": "Used to define an item contained in a select, an optgroup, or a datalist element."
     },
     "output": {
       "attributes": [
         "for",
         "form",
         "name"
-      ]
+      ],
+      "description": "Represents the result of a calculation or user action."
     },
-    "p": {},
+    "p": {
+      "description": "Represents a paragraph of text."
+    },
     "param": {
       "attributes": [
         "name",
         "value"
-      ]
+      ],
+      "description": "Defines parameters for an object element."
     },
-    "pre": {},
+    "pre": {
+      "description": "Represents preformatted text."
+    },
     "progress": {
       "attributes": [
         "form",
         "max",
         "value"
-      ]
+      ],
+      "description": "Represents the completion progress of a task, typically displayed as a progress bar."
     },
     "q": {
       "attributes": [
         "cite"
-      ]
+      ],
+      "description": "Indicates that the enclosed text is a short inline quotation."
     },
-    "rp": {},
-    "rt": {},
-    "ruby": {},
-    "samp": {},
+    "rp": {
+      "description": "Used to provide fall-back parentheses for browsers that do not support display of ruby annotations using the ruby element."
+    },
+    "rt": {
+      "description": "Embraces pronunciation of characters presented in a ruby annotations, which are used to describe the pronunciation of East Asian characters."
+    },
+    "ruby": {
+      "description": "Represents a ruby annotation."
+    },
+    "samp": {
+      "description": "An element intended to identify sample output from a computer program."
+    },
     "script": {
       "attributes": [
         "async",
@@ -410,9 +539,12 @@
         "defer",
         "src",
         "type"
-      ]
+      ],
+      "description": "Used to embed or reference an executable script."
     },
-    "section": {},
+    "section": {
+      "description": "Represents a standalone section of functionality contained within an HTML document, typically with a heading, which doesn't have a more specific semantic element to represent it."
+    },
     "select": {
       "attributes": [
         "autofocus",
@@ -422,46 +554,66 @@
         "name",
         "required",
         "size"
-      ]
+      ],
+      "description": "Represents a control that provides a menu of options:"
     },
-    "small": {},
+    "small": {
+      "description": "Makes the text font size one size smaller (for example, from large to medium, or from small to x-small) down to the browser's minimum font size."
+    },
     "source": {
       "attributes": [
         "media",
         "src",
         "type"
-      ]
+      ],
+      "description": "Specifies multiple media resources for either the picture, the audio or the video element."
     },
-    "span": {},
-    "strong": {},
+    "span": {
+      "description": "A generic inline container for phrasing content, which does not inherently represent anything."
+    },
+    "strong": {
+      "description": "Gives text strong importance, and is typically displayed in bold."
+    },
     "style": {
       "attributes": [
         "disabled",
         "media",
         "scoped",
         "type"
-      ]
+      ],
+      "description": "Contains style information for a document, or part of a document."
     },
-    "sub": {},
-    "summary": {},
-    "sup": {},
+    "sub": {
+      "description": "Defines a span of text that should be displayed, for typographic reasons, lower, and often smaller, than the main span of text."
+    },
+    "summary": {
+      "description": "Used as a summary, caption, or legend for the content of a details element."
+    },
+    "sup": {
+      "description": "Defines a span of text that should be displayed, for typographic reasons, higher, and often smaller, than the main span of text."
+    },
     "table": {
       "attributes": [
         "border"
-      ]
+      ],
+      "description": "Represents tabular data —that is, information expressed via a two-dimensional data table."
     },
-    "tbody": {},
+    "tbody": {
+      "description": "Groups one or more tr elements as the body of a table element."
+    },
     "td": {
       "attributes": [
         "colspan",
         "headers",
         "rowspan"
-      ]
+      ],
+      "description": "Defines a cell of a table that contains data."
     },
     "template": {
       "attributes": [
         "content"
-      ]
+      ],
+      "description": "A mechanism for holding client-side content that is not to be rendered when a page is loaded but may subsequently be instantiated during runtime using JavaScript."
     },
     "textarea": {
       "attributes": [
@@ -478,26 +630,37 @@
         "required",
         "rows",
         "wrap"
-      ]
+      ],
+      "description": "Represents a multi-line plain-text editing control."
     },
-    "tfoot": {},
+    "tfoot": {
+      "description": "Defines a set of rows summarizing the columns of the table."
+    },
     "th": {
       "attributes": [
         "colspan",
         "headers",
         "rowspan",
         "scope"
-      ]
+      ],
+      "description": "Defines a cell as header of a group of table cells."
     },
-    "thead": {},
+    "thead": {
+      "description": "Defines a set of rows defining the head of the columns of the table."
+    },
     "time": {
       "attributes": [
         "datetime",
         "pubdate"
-      ]
+      ],
+      "description": "Represents either a time on a 24-hour clock or a precise date in the Gregorian calendar (with optional time and timezone information)."
     },
-    "title": {},
-    "tr": {},
+    "title": {
+      "description": "Defines the title of the document, shown in a browser's title bar or on the page's tab."
+    },
+    "tr": {
+      "description": "Defines a row of cells in a table."
+    },
     "track": {
       "attributes": [
         "default",
@@ -505,11 +668,18 @@
         "label",
         "src",
         "srclang"
-      ]
+      ],
+      "description": "Used as a child of the media elements— audio and video."
     },
-    "tt": {},
-    "ul": {},
-    "var": {},
+    "tt": {
+      "description": "The tt element is obsolete. Avoid using it and update existing code if possible."
+    },
+    "ul": {
+      "description": "Represents an unordered list of items, typically rendered as a bulleted list."
+    },
+    "var": {
+      "description": "Represents a variable in a mathematical expression or a programming context."
+    },
     "video": {
       "attributes": [
         "autoplay",
@@ -522,31 +692,39 @@
         "preload",
         "src",
         "width"
-      ]
+      ],
+      "description": "Use the HTML video element to embed video content in a document."
     },
-    "wbr": {}
+    "wbr": {
+      "description": "Represents a word break opportunity—a position within text where the browser may optionally break a line, though its line-breaking rules would not otherwise create a break at that location."
+    }
   },
   "attributes": {
     "accesskey": {
-      "global": "true"
+      "global": "true",
+      "description": "Provides a hint for generating a keyboard shortcut for the current element."
     },
     "class": {
       "global": "true",
-      "type": "cssStyle"
+      "type": "cssStyle",
+      "description": "A space-separated list of the classes of the element."
     },
     "contenteditable": {
       "global": "true",
-      "type": "boolean"
+      "type": "boolean",
+      "description": "An enumerated attribute indicating if the element should be editable by the user."
     },
     "contextmenu": {
-      "global": "true"
+      "global": "true",
+      "description": "The id of a menu to use as the contextual menu for this element."
     },
     "dir": {
       "attribOption": [
         "ltr",
         "rtl"
       ],
-      "global": "true"
+      "global": "true",
+      "description": "An enumerated attribute indicates the directionality of the element's text."
     },
     "draggable": {
       "attribOption": [
@@ -554,7 +732,8 @@
         "false",
         "true"
       ],
-      "global": "true"
+      "global": "true",
+      "description": "An enumerated attribute that indicates whether the element can be dragged, using the HTML Drag and Drop API."
     },
     "dropzone": {
       "attribOption": [
@@ -562,17 +741,20 @@
         "move",
         "link"
       ],
-      "global": "true"
+      "global": "true",
+      "description": "An enumerated attribute indicating what types of content can be dropped on an element, using the Drag and Drop API."
     },
     "hidden": {
       "attribOption": [
         "hidden"
       ],
-      "global": "true"
+      "global": "true",
+      "description": "A Boolean attribute indicating that the element is not yet, or is no longer, relevant."
     },
     "id": {
       "global": "true",
-      "type": "cssId"
+      "type": "cssId",
+      "description": "Defines a unique identifier (ID) which must be unique in the whole document."
     },
     "lang": {
       "attribOption": [
@@ -722,7 +904,8 @@
         "yo",
         "zu"
       ],
-      "global": "true"
+      "global": "true",
+      "description": "Participates in defining the language of the element, the language that its non-editable elements are written in or the language that the editable elements should be written in."
     },
     "role": {
       "attribOption": [
@@ -792,17 +975,21 @@
     },
     "spellcheck": {
       "global": "true",
-      "type": "boolean"
+      "type": "boolean",
+      "description": "An enumerated attribute defines whether the element may be checked for spelling errors."
     },
     "style": {
       "global": "true",
-      "type": "style"
+      "type": "style",
+      "description": "Contains CSS styling declarations to be applied to the element."
     },
     "tabindex": {
-      "global": "true"
+      "global": "true",
+      "description": "An integer indicating if the element can take input focus (is focusable), if it should participate to sequential keyboard navigation, and if so, at what position."
     },
     "title": {
-      "global": "true"
+      "global": "true",
+      "description": "Contains text representing advisory information, related to the element it belongs to."
     },
     "onabort": {
       "global": "true"

--- a/fetch-global-attribute-docs.coffee
+++ b/fetch-global-attribute-docs.coffee
@@ -1,0 +1,88 @@
+path = require 'path'
+fs = require 'fs'
+request = require 'request'
+
+mdnHTMLURL = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes'
+mdnJSONAPI = 'https://developer.mozilla.org/en-US/search.json?topic=html&highlight=false'
+AttributesURL = 'https://raw.githubusercontent.com/adobe/brackets/master/src/extensions/default/HTMLCodeHints/HtmlAttributes.json'
+
+fetch = ->
+  attributesPromise = new Promise (resolve) ->
+    request {json: true, url: AttributesURL}, (error, response, attributes) ->
+      if error?
+        console.error(error.message)
+        resolve(null)
+
+      if response.statusCode isnt 200
+        console.error("Request for HtmlAttributes.json failed: #{response.statusCode}")
+        resolve(null)
+
+      resolve(attributes)
+
+  attributesPromise.then (attributes) ->
+    return unless attributes?
+
+    MAX = 10
+    queue = []
+    for attribute, options of attributes
+      # MDN is missing docs for aria attributes and on* event handlers
+      if options.global and not attribute.startsWith('aria') and not attribute.startsWith('on') and attribute isnt 'role'
+        queue.push(attribute)
+    running = []
+    docs = {}
+
+    new Promise (resolve) ->
+      checkEnd = ->
+        resolve(docs) if queue.length is 0 and running.length is 0
+
+      removeRunning = (attributeName) ->
+        index = running.indexOf(attributeName)
+        running.splice(index, 1) if index > -1
+
+      runNext = ->
+        checkEnd()
+        if queue.length isnt 0
+          attributeName = queue.pop()
+          running.push(attributeName)
+          run(attributeName)
+
+      run = (attributeName) ->
+        url = "#{mdnJSONAPI}&q=#{attributeName}"
+        request {json: true, url}, (error, response, searchResults) ->
+          if not error? and response.statusCode is 200
+            handleRequest(attributeName, searchResults)
+          else
+            console.error "Req failed #{url}; #{response.statusCode}, #{error}"
+          removeRunning(attributeName)
+          runNext()
+
+      handleRequest = (attributeName, searchResults) ->
+        if searchResults.documents?
+          for doc in searchResults.documents
+            if doc.url is "#{mdnHTMLURL}/#{attributeName}"
+              docs[attributeName] = filterExcerpt(attributeName, doc.excerpt)
+              return
+        console.log "Could not find documentation for #{attributeName}"
+
+      runNext() for [0..MAX]
+      return
+
+filterExcerpt = (attributeName, excerpt) ->
+  beginningPattern = /^the [a-z-]+ global attribute (is )?(\w+)/i
+  excerpt = excerpt.replace beginningPattern, (match) ->
+    matches = beginningPattern.exec(match)
+    firstWord = matches[2]
+    firstWord[0].toUpperCase() + firstWord.slice(1)
+  periodIndex = excerpt.indexOf('.')
+  excerpt = excerpt.slice(0, periodIndex + 1) if periodIndex > -1
+  excerpt
+
+# Save a file if run from the command line
+if require.main is module
+  fetch().then (docs) ->
+    if docs?
+      fs.writeFileSync(path.join(__dirname, 'global-attribute-docs.json'), "#{JSON.stringify(docs, null, '  ')}\n")
+    else
+      console.error 'No docs'
+
+module.exports = fetch

--- a/fetch-tag-docs.coffee
+++ b/fetch-tag-docs.coffee
@@ -1,0 +1,90 @@
+path = require 'path'
+fs = require 'fs'
+request = require 'request'
+
+mdnHTMLURL = 'https://developer.mozilla.org/en-US/docs/Web/HTML/Element'
+mdnJSONAPI = 'https://developer.mozilla.org/en-US/search.json?topic=html&highlight=false'
+TagsURL = 'https://raw.githubusercontent.com/adobe/brackets/master/src/extensions/default/HTMLCodeHints/HtmlTags.json'
+
+fetch = ->
+  tagsPromise = new Promise (resolve) ->
+    request {json: true, url: TagsURL}, (error, response, tags) ->
+      if error?
+        console.error(error.message)
+        resolve(null)
+
+      if response.statusCode isnt 200
+        console.error("Request for HtmlTags.json failed: #{response.statusCode}")
+        resolve(null)
+
+      resolve(tags)
+
+  tagsPromise.then (tags) ->
+    return unless tags?
+
+    MAX = 10
+    queue = Object.keys(tags)
+    running = []
+    docs = {}
+
+    new Promise (resolve) ->
+      checkEnd = ->
+        resolve(docs) if queue.length is 0 and running.length is 0
+
+      removeRunning = (tagName) ->
+        index = running.indexOf(tagName)
+        running.splice(index, 1) if index > -1
+
+      runNext = ->
+        checkEnd()
+        if queue.length isnt 0
+          tagName = queue.pop()
+          running.push(tagName)
+          run(tagName)
+
+      run = (tagName) ->
+        url = "#{mdnJSONAPI}&q=#{tagName}"
+        request {json: true, url}, (error, response, searchResults) ->
+          if not error? and response.statusCode is 200
+            handleRequest(tagName, searchResults)
+          else
+            console.error "Req failed #{url}; #{response.statusCode}, #{error}"
+          removeRunning(tagName)
+          runNext()
+
+      handleRequest = (tagName, searchResults) ->
+        if searchResults.documents?
+          for doc in searchResults.documents
+            # MDN groups h1 through h6 under a single "Heading Elements" page
+            if doc.url is "#{mdnHTMLURL}/#{tagName}" or (/^h\d$/.test(tagName) and doc.url is "#{mdnHTMLURL}/Heading_Elements")
+              if doc.tags.includes('Obsolete')
+                docs[tagName] = "The #{tagName} element is obsolete. Avoid using it and update existing code if possible."
+              else if doc.tags.includes('Deprecated')
+                docs[tagName] = "The #{tagName} element is deprecated. Avoid using it and update existing code if possible."
+              else
+                docs[tagName] = filterExcerpt(tagName, doc.excerpt)
+              return
+        console.log "Could not find documentation for #{tagName}"
+
+      runNext() for [0..MAX]
+      return
+
+filterExcerpt = (tagName, excerpt) ->
+  beginningPattern = /^the html [a-z-]+ element (\([^)]+\) )?(is )?(\w+)/i
+  excerpt = excerpt.replace beginningPattern, (match) ->
+    matches = beginningPattern.exec(match)
+    firstWord = matches[3]
+    firstWord[0].toUpperCase() + firstWord.slice(1)
+  periodIndex = excerpt.indexOf('.')
+  excerpt = excerpt.slice(0, periodIndex + 1) if periodIndex > -1
+  excerpt
+
+# Save a file if run from the command line
+if require.main is module
+  fetch().then (docs) ->
+    if docs?
+      fs.writeFileSync(path.join(__dirname, 'tag-docs.json'), "#{JSON.stringify(docs, null, '  ')}\n")
+    else
+      console.error 'No docs'
+
+module.exports = fetch

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -96,7 +96,7 @@ module.exports =
     text: tag
     type: 'tag'
     description: description ? "HTML <#{tag}> tag"
-    descriptionMoreURL: @getTagDocsURL(tag)
+    descriptionMoreURL: if description then @getTagDocsURL(tag) else null
 
   getAttributeNameCompletions: ({editor, bufferPosition}, prefix) ->
     completions = []
@@ -124,7 +124,7 @@ module.exports =
     displayText: attribute
     type: 'attribute'
     description: description ? "Global #{attribute} attribute"
-    descriptionMoreURL: @getGlobalAttributeDocsURL(attribute)
+    descriptionMoreURL: if description then @getGlobalAttributeDocsURL(attribute) else null
 
   getAttributeValueCompletions: ({editor, bufferPosition}, prefix) ->
     tag = @getPreviousTag(editor, bufferPosition)

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -129,7 +129,7 @@ module.exports =
   getAttributeValueCompletions: ({editor, bufferPosition}, prefix) ->
     tag = @getPreviousTag(editor, bufferPosition)
     attribute = @getPreviousAttribute(editor, bufferPosition)
-    values = @getAttributeValues(attribute)
+    values = @getAttributeValues(tag, attribute)
     for value in values when not prefix or firstCharsEqual(value, prefix)
       @buildAttributeValueCompletion(tag, attribute, value)
 
@@ -142,6 +142,7 @@ module.exports =
     else
       text: value
       type: 'value'
+      rightLabel: "<#{tag}>"
       description: "#{value} value for #{attribute} attribute local to <#{tag}>"
       descriptionMoreURL: @getLocalAttributeDocsURL(attribute, tag)
 
@@ -163,9 +164,10 @@ module.exports =
 
     attributePattern.exec(line)?[1]
 
-  getAttributeValues: (attribute) ->
-    attribute = @completions.attributes[attribute]
-    attribute?.attribOption ? []
+  getAttributeValues: (tag, attribute) ->
+    # Some local attributes are valid for multiple tags but have different attribute values
+    # To differentiate them, they are identified in the completions file as tag/attribute
+    @completions.attributes[attribute]?.attribOption ? @completions.attributes["#{tag}/#{attribute}"]?.attribOption ? []
 
   getTagAttributes: (tag) ->
     @completions.tags[tag]?.attributes ? []

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -88,14 +88,14 @@ module.exports =
 
   getTagNameCompletions: (prefix) ->
     completions = []
-    for tag, attributes of @completions.tags when not prefix or firstCharsEqual(tag, prefix)
-      completions.push(@buildTagCompletion(tag))
+    for tag, options of @completions.tags when not prefix or firstCharsEqual(tag, prefix)
+      completions.push(@buildTagCompletion(tag, options))
     completions
 
-  buildTagCompletion: (tag) ->
+  buildTagCompletion: (tag, {description}) ->
     text: tag
     type: 'tag'
-    description: "HTML <#{tag}> tag"
+    description: description ? "HTML <#{tag}> tag"
     descriptionMoreURL: @getTagDocsURL(tag)
 
   getAttributeNameCompletions: ({editor, bufferPosition}, prefix) ->
@@ -104,27 +104,27 @@ module.exports =
     tagAttributes = @getTagAttributes(tag)
 
     for attribute in tagAttributes when not prefix or firstCharsEqual(attribute, prefix)
-      completions.push(@buildAttributeCompletion(attribute, tag))
+      completions.push(@buildLocalAttributeCompletion(attribute, tag))
 
     for attribute, options of @completions.attributes when not prefix or firstCharsEqual(attribute, prefix)
-      completions.push(@buildAttributeCompletion(attribute)) if options.global
+      completions.push(@buildGlobalAttributeCompletion(attribute, options)) if options.global
 
     completions
 
-  buildAttributeCompletion: (attribute, tag) ->
-    if tag?
-      snippet: "#{attribute}=\"$1\"$0"
-      displayText: attribute
-      type: 'attribute'
-      rightLabel: "<#{tag}>"
-      description: "#{attribute} attribute local to <#{tag}> tags"
-      descriptionMoreURL: @getLocalAttributeDocsURL(attribute, tag)
-    else
-      snippet: "#{attribute}=\"$1\"$0"
-      displayText: attribute
-      type: 'attribute'
-      description: "Global #{attribute} attribute"
-      descriptionMoreURL: @getGlobalAttributeDocsURL(attribute)
+  buildLocalAttributeCompletion: (attribute, tag) ->
+    snippet: "#{attribute}=\"$1\"$0"
+    displayText: attribute
+    type: 'attribute'
+    rightLabel: "<#{tag}>"
+    description: "#{attribute} attribute local to <#{tag}> tags"
+    descriptionMoreURL: @getLocalAttributeDocsURL(attribute, tag)
+
+  buildGlobalAttributeCompletion: (attribute, {description}) ->
+    snippet: "#{attribute}=\"$1\"$0"
+    displayText: attribute
+    type: 'attribute'
+    description: description ? "Global #{attribute} attribute"
+    descriptionMoreURL: @getGlobalAttributeDocsURL(attribute)
 
   getAttributeValueCompletions: ({editor, bufferPosition}, prefix) ->
     tag = @getPreviousTag(editor, bufferPosition)

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -58,6 +58,7 @@ describe "HTML autocompletions", ->
 
     completions = getCompletions()
     expect(completions.length).toBe 113
+    expect(completions[0].description).toContain 'Creates a hyperlink to other web pages'
     expect(completions[0].descriptionMoreURL.endsWith('/HTML/Element/a')).toBe true
 
     for completion in completions
@@ -107,6 +108,7 @@ describe "HTML autocompletions", ->
 
     completions = getCompletions()
     expect(completions.length).toBe 86
+    expect(completions[0].description).toContain 'Provides a hint for generating a keyboard shortcut'
     expect(completions[0].descriptionMoreURL.endsWith('/HTML/Global_attributes/accesskey')).toBe true
 
     for completion in completions

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -195,7 +195,6 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions.length).toBe 3
 
-    console.log completions[0].descriptionMoreURL
     expect(completions[0].text).toBe 'scroll'
     expect(completions[0].type).toBe 'value'
     expect(completions[0].description.length).toBeGreaterThan 0
@@ -273,6 +272,31 @@ describe "HTML autocompletions", ->
     expect(completions[3].text).toBe 'et'
     expect(completions[4].text).toBe 'el'
     expect(completions[5].text).toBe 'es'
+
+  it "autocompletes ambiguous attribute values", ->
+    editor.setText('<button type=""')
+    editor.setCursorBufferPosition([0, 14])
+
+    completions = getCompletions()
+    expect(completions.length).toBe 3
+
+    expect(completions[0].text).toBe 'button'
+    expect(completions[0].type).toBe 'value'
+    expect(completions[0].description.length).toBeGreaterThan 0
+    expect(completions[0].descriptionMoreURL.endsWith('/HTML/Element/button#attr-type')).toBe true
+    expect(completions[1].text).toBe 'reset'
+    expect(completions[2].text).toBe 'submit'
+
+    editor.setText('<link type=""')
+    editor.setCursorBufferPosition([0, 12])
+
+    completions = getCompletions()
+    expect(completions.length).toBe 1
+
+    expect(completions[0].text).toBe 'text/css'
+    expect(completions[0].type).toBe 'value'
+    expect(completions[0].description.length).toBeGreaterThan 0
+    expect(completions[0].descriptionMoreURL.endsWith('/HTML/Element/link#attr-type')).toBe true
 
   it "triggers autocomplete when an attibute has been inserted", ->
     spyOn(atom.commands, 'dispatch')

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -110,6 +110,7 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
 
     expect(completions[2].text).toBe 'ilayer'
+    expect(completions[2].description).toBe 'HTML <ilayer> tag'
     expect(completions[2].descriptionMoreURL).toBeNull()
 
   it "autocompletes attribute names without a prefix", ->
@@ -205,6 +206,7 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
 
     expect(completions[0].displayText).toBe 'onabort'
+    expect(completions[0].description).toBe 'Global onabort attribute'
     expect(completions[0].descriptionMoreURL).toBeNull()
 
   it "autocompletes attribute values without a prefix", ->

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -102,6 +102,16 @@ describe "HTML autocompletions", ->
     expect(completions[7].text).toBe 'dl'
     expect(completions[8].text).toBe 'dt'
 
+  it "does not provide a descriptionMoreURL if the tag does not have a unique description", ->
+    # ilayer does not have an associated MDN page as of April 27, 2017
+    editor.setText('<i')
+    editor.setCursorBufferPosition([0, 2])
+
+    completions = getCompletions()
+
+    expect(completions[2].text).toBe 'ilayer'
+    expect(completions[2].descriptionMoreURL).toBeNull()
+
   it "autocompletes attribute names without a prefix", ->
     editor.setText('<div ')
     editor.setCursorBufferPosition([0, 5])
@@ -187,6 +197,15 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions[0].displayText).toBe 'direction'
     expect(completions[1].displayText).toBe 'dir'
+
+  it "does not provide a descriptionMoreURL if the attribute does not have a unique description", ->
+    editor.setText('<input on')
+    editor.setCursorBufferPosition([0, 9])
+
+    completions = getCompletions()
+
+    expect(completions[0].displayText).toBe 'onabort'
+    expect(completions[0].descriptionMoreURL).toBeNull()
 
   it "autocompletes attribute values without a prefix", ->
     editor.setText('<marquee behavior=""')

--- a/update.coffee
+++ b/update.coffee
@@ -38,7 +38,6 @@ attributesPromise = new Promise (resolve) ->
       resolve(null)
 
     for attribute, options of attributes
-      delete attributes[attribute] if attribute.indexOf('/') isnt -1
       delete options.attribOption if options.attribOption?.length is 0
 
     resolve(attributes)

--- a/update.coffee
+++ b/update.coffee
@@ -4,50 +4,58 @@
 path = require 'path'
 fs = require 'fs'
 request = require 'request'
+fetchTagDescriptions = require './fetch-tag-docs'
+fetchGlobalAttributeDescriptions = require './fetch-global-attribute-docs'
 
-exitIfError = (error) ->
-  if error?
-    console.error(error.message)
-    return process.exit(1)
+TagsURL = 'https://raw.githubusercontent.com/adobe/brackets/master/src/extensions/default/HTMLCodeHints/HtmlTags.json'
+AttributesURL = 'https://raw.githubusercontent.com/adobe/brackets/master/src/extensions/default/HTMLCodeHints/HtmlAttributes.json'
 
-getTags = (callback) ->
-  requestOptions =
-    url: 'https://raw.githubusercontent.com/adobe/brackets/master/src/extensions/default/HTMLCodeHints/HtmlTags.json'
-    json: true
-
-  request requestOptions, (error, response, tags) ->
-    return callback(error) if error?
+tagsPromise = new Promise (resolve) ->
+  request {json: true, url: TagsURL}, (error, response, tags) ->
+    if error?
+      console.error(error.message)
+      resolve(null)
 
     if response.statusCode isnt 200
-      return callback(new Error("Request for HtmlTags.json failed: #{response.statusCode}"))
+      console.error("Request for HtmlTags.json failed: #{response.statusCode}")
+      resolve(null)
 
     for tag, options of tags
       delete options.attributes if options.attributes?.length is 0
 
-    callback(null, tags)
+    resolve(tags)
 
-getAttributes = (callback) ->
-  requestOptions =
-    url: 'https://raw.githubusercontent.com/adobe/brackets/master/src/extensions/default/HTMLCodeHints/HtmlAttributes.json'
-    json: true
+tagDescriptionsPromise = fetchTagDescriptions()
 
-  request requestOptions, (error, response, attributes) ->
-    return callback(error) if error?
+attributesPromise = new Promise (resolve) ->
+  request {json: true, url: AttributesURL}, (error, response, attributes) ->
+    if error?
+      console.error(error.message)
+      resolve(null)
 
     if response.statusCode isnt 200
-      return callback(new Error("Request for HtmlAttributes.json failed: #{response.statusCode}"))
+      console.error("Request for HtmlAttributes.json failed: #{response.statusCode}")
+      resolve(null)
 
     for attribute, options of attributes
       delete attributes[attribute] if attribute.indexOf('/') isnt -1
       delete options.attribOption if options.attribOption?.length is 0
 
-    callback(null, attributes)
+    resolve(attributes)
 
-getTags (error, tags) ->
-  exitIfError(error)
+globalAttributeDescriptionsPromise = fetchGlobalAttributeDescriptions()
 
-  getAttributes (error, attributes) ->
-    exitIfError(error)
+Promise.all([tagsPromise, tagDescriptionsPromise, attributesPromise, globalAttributeDescriptionsPromise]).then (values) ->
+  tags = values[0]
+  tagDescriptions = values[1]
+  attributes = values[2]
+  attributeDescriptions = values[3]
 
-    completions = {tags, attributes}
-    fs.writeFileSync(path.join(__dirname, 'completions.json'), "#{JSON.stringify(completions, null, '  ')}\n")
+  for tag of tags
+    tags[tag].description = tagDescriptions[tag]
+
+  for attribute, options of attributes
+    attributes[attribute].description = attributeDescriptions[attribute] if options.global
+
+  completions = {tags, attributes}
+  fs.writeFileSync(path.join(__dirname, 'completions.json'), "#{JSON.stringify(completions, null, '  ')}\n")


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Add proper descriptions sourced from MDN for tags and global attributes.

|Before|After|
|-------|------|
|![tag-before](https://cloud.githubusercontent.com/assets/2766036/25511001/2e681fa8-2b92-11e7-9cc9-f55b0f2d7046.png)|![tag-after](https://cloud.githubusercontent.com/assets/2766036/25511014/43586684-2b92-11e7-94ff-6dbfbaadc95f.png)|
|![global-attribute-before](https://cloud.githubusercontent.com/assets/2766036/25511043/73d99530-2b92-11e7-8864-4d60ac35fc82.png)|![global-attribute-after](https://cloud.githubusercontent.com/assets/2766036/25511036/656146ec-2b92-11e7-9871-2b6ee1584e59.png)|

When a description is not available, the "before" description is used and the "More..." URL is not generated (to prevent linking to a 404 page).

In addition, suggestions are now provided for ambiguous local attributes (ie, local attributes that are used by more than one tag but have different values for each tag).  Those were previously being ignored when generating the completions file.

|Before|After|
|-------|------|
|![ambiguous-suggestions-before](https://cloud.githubusercontent.com/assets/2766036/25511495/1687cf3e-2b95-11e7-8db6-33bd59d7cc5f.png)|![ambiguous-suggestions-after](https://cloud.githubusercontent.com/assets/2766036/25511465/016b0fe4-2b95-11e7-8366-e560ed7c9213.png)|

I also converted the update files to use promises instead of callbacks.

### Alternate Designs

None.

### Benefits

This change should lead to improved clarity of what tags and global attributes do.  The previous descriptions weren't too helpful.

### Possible Drawbacks

All of the `on*` event handlers and `aria*` accessibility global attributes don't have specific MDN pages, so descriptions cannot be shown for those.

### Applicable Issues

Fixes #50
Fixes https://github.com/atom/autocomplete-html/issues/38#issuecomment-257210469
Fixes #37
Fixes #35