### PR TITLE
Respect the 'flag' type when autocompleting attribute names

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -104,23 +104,23 @@ module.exports =
     tagAttributes = @getTagAttributes(tag)
 
     for attribute in tagAttributes when not prefix or firstCharsEqual(attribute, prefix)
-      completions.push(@buildLocalAttributeCompletion(attribute, tag))
+      completions.push(@buildLocalAttributeCompletion(attribute, tag, @completions.attributes[attribute]))
 
     for attribute, options of @completions.attributes when not prefix or firstCharsEqual(attribute, prefix)
       completions.push(@buildGlobalAttributeCompletion(attribute, options)) if options.global
 
     completions
 
-  buildLocalAttributeCompletion: (attribute, tag) ->
-    snippet: "#{attribute}=\"$1\"$0"
+  buildLocalAttributeCompletion: (attribute, tag, {type}) ->
+    snippet: if type is 'flag' then attribute else "#{attribute}=\"$1\"$0"
     displayText: attribute
     type: 'attribute'
     rightLabel: "<#{tag}>"
     description: "#{attribute} attribute local to <#{tag}> tags"
     descriptionMoreURL: @getLocalAttributeDocsURL(attribute, tag)
 
-  buildGlobalAttributeCompletion: (attribute, {description}) ->
-    snippet: "#{attribute}=\"$1\"$0"
+  buildGlobalAttributeCompletion: (attribute, {description, type}) ->
+    snippet: if type is 'flag' then attribute else "#{attribute}=\"$1\"$0"
     displayText: attribute
     type: 'attribute'
     description: description ? "Global #{attribute} attribute"

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -199,6 +199,13 @@ describe "HTML autocompletions", ->
     expect(completions[0].displayText).toBe 'direction'
     expect(completions[1].displayText).toBe 'dir'
 
+  it "respects the 'flag' type when autocompleting attribute names", ->
+    editor.setText('<select ')
+    editor.setCursorBufferPosition([0, 8])
+
+    completions = getCompletions()
+    expect(completions[0].snippet).toBe 'autofocus'
+
   it "does not provide a descriptionMoreURL if the attribute does not have a unique description", ->
     editor.setText('<input on')
     editor.setCursorBufferPosition([0, 9])


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Certain HTML attributes are boolean and do not need a value, eg `autofocus` and `checked`.  Do not attempt to give them a value if the `flag` type is set in the completions file.

### Alternate Designs

None.

### Benefits

Less confusion (why doesn't `checked="false"` work?) and better adherence to the HTML5 spec.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #15