### PR TITLE
Autocomplete 'true' and 'false' for boolean attributes

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -127,11 +127,18 @@ module.exports =
     descriptionMoreURL: if description then @getGlobalAttributeDocsURL(attribute) else null
 
   getAttributeValueCompletions: ({editor, bufferPosition}, prefix) ->
+    completions = []
     tag = @getPreviousTag(editor, bufferPosition)
     attribute = @getPreviousAttribute(editor, bufferPosition)
     values = @getAttributeValues(tag, attribute)
     for value in values when not prefix or firstCharsEqual(value, prefix)
-      @buildAttributeValueCompletion(tag, attribute, value)
+      completions.push(@buildAttributeValueCompletion(tag, attribute, value))
+
+    if completions.length is 0 and @completions.attributes[attribute].type is 'boolean'
+      completions.push(@buildAttributeValueCompletion(tag, attribute, 'true'))
+      completions.push(@buildAttributeValueCompletion(tag, attribute, 'false'))
+
+    completions
 
   buildAttributeValueCompletion: (tag, attribute, value) ->
     if @completions.attributes[attribute].global

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -326,6 +326,15 @@ describe "HTML autocompletions", ->
     expect(completions[0].description.length).toBeGreaterThan 0
     expect(completions[0].descriptionMoreURL.endsWith('/HTML/Element/link#attr-type')).toBe true
 
+  it "provides 'true' and 'false' suggestions when autocompleting boolean attributes", ->
+    editor.setText('<html contenteditable=""')
+    editor.setCursorBufferPosition([0, 23])
+
+    completions = getCompletions()
+    expect(completions.length).toBe 2
+    expect(completions[0].text).toBe 'true'
+    expect(completions[1].text).toBe 'false'
+
   it "triggers autocomplete when an attibute has been inserted", ->
     spyOn(atom.commands, 'dispatch')
     suggestion = {type: 'attribute', text: 'whatever'}


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

There are a few boolean attributes in HTML, such as `contenteditable` or `spellcheck`.  When autocompleting those, `true` and `false` should be offered as potential values.

### Alternate Designs

None.

### Benefits

Less typing.

### Possible Drawbacks

None.

### Applicable Issues

None.