### PR TITLE
Autocomplete attribute names surrounded by whitespace

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -52,12 +52,18 @@ module.exports =
     return false unless trailingWhitespace.test(prefix)
     @hasTagScope(scopeDescriptor.getScopesArray())
 
-  isAttributeStartWithPrefix: ({prefix, scopeDescriptor}) ->
+  isAttributeStartWithPrefix: ({prefix, scopeDescriptor, bufferPosition, editor}) ->
     return false unless prefix
     return false if trailingWhitespace.test(prefix)
 
     scopes = scopeDescriptor.getScopesArray()
-    return true if scopes.indexOf('entity.other.attribute-name.html') isnt -1
+
+    previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - 1)]
+    previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
+    previousScopesArray = previousScopes.getScopesArray()
+
+    return true if scopes.indexOf('entity.other.attribute-name.html') isnt -1 or
+      previousScopesArray.indexOf('entity.other.attribute-name.html') isnt -1
     return false unless @hasTagScope(scopes)
 
     scopes.indexOf('punctuation.definition.tag.html') isnt -1 or

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -199,6 +199,22 @@ describe "HTML autocompletions", ->
     expect(completions[0].displayText).toBe 'direction'
     expect(completions[1].displayText).toBe 'dir'
 
+  it "autocompletes attribute names without a prefix surrounded by whitespace", ->
+    editor.setText('<select  autofocus')
+    editor.setCursorBufferPosition([0, 8])
+
+    completions = getCompletions()
+    expect(completion.type).toBe 'attribute' for completion in completions
+    expect(completions[0].displayText).toBe 'autofocus'
+
+  it "autocompletes attribute names with a prefix surrounded by whitespace", ->
+    editor.setText('<select o autofocus')
+    editor.setCursorBufferPosition([0, 9])
+
+    completions = getCompletions()
+    expect(completion.type).toBe 'attribute' for completion in completions
+    expect(completions[0].displayText).toBe 'onabort'
+
   it "respects the 'flag' type when autocompleting attribute names", ->
     editor.setText('<select ')
     editor.setCursorBufferPosition([0, 8])


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Attribute names surrounded by whitespace were being recognized as tags instead of attributes due to a small bug in the scope checking.  The previous editor position's scopes need to be checked as well because if you are just starting to type the attribute, there will be no relevant scopes at the current editor position.  The reason this bug didn't manifest for incomplete attribute names at the end of the line (as is what happens in the majority of cases) is due to a quirk in how scopes are calculated: the scopes don't change until a new character is added (not sure if this is a bug or not).  See the following examples for some clarification.
```html
<select a
        ^^ entity.other.attribute-name.html (EOL, scopes don't update) -->
```
```html
<select a autofocus
        ^ entity.other.attribute-name.html
         ^ nothing (because there are other characters following)
```

### Alternate Designs

Textmate could be checked to see if their scopes behave the same way, but I don't have a Mac.

### Benefits

You can now go back and edit or add an attribute in the middle of the tag.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #25