### PR TITLE
Don't throw when a local attribute is missing

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -117,8 +117,8 @@ module.exports =
 
     completions
 
-  buildLocalAttributeCompletion: (attribute, tag, {type}) ->
-    snippet: if type is 'flag' then attribute else "#{attribute}=\"$1\"$0"
+  buildLocalAttributeCompletion: (attribute, tag, options) ->
+    snippet: if options?.type is 'flag' then attribute else "#{attribute}=\"$1\"$0"
     displayText: attribute
     type: 'attribute'
     rightLabel: "<#{tag}>"

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -222,6 +222,15 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions[0].snippet).toBe 'autofocus'
 
+  it "does not throw when a local attribute is not in the attributes list", ->
+    # Some tags, like body, have local attributes that are not present in the top-level attributes array
+    editor.setText('<body ')
+    editor.setCursorBufferPosition([0, 6])
+
+    completions = []
+    expect(-> completions = getCompletions()).not.toThrow()
+    expect(completions[0].displayText).toBe 'onafterprint'
+
   it "does not provide a descriptionMoreURL if the attribute does not have a unique description", ->
     editor.setText('<input on')
     editor.setCursorBufferPosition([0, 9])


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Some tags, like body, have local attributes that are not present in the top-level attributes array (I guess that's a consequence of having two separate files that aren't always kept in sync).  When that occurs, don't throw when attempting to find the attribute's options.

### Alternate Designs

None.

### Benefits

Less uncaught exceptions

### Possible Drawbacks

None.

### Applicable Issues

None.