### PR TITLE
Don't attempt to autocomplete before/after strings

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -69,17 +69,29 @@ module.exports =
     scopes.indexOf('punctuation.definition.tag.html') isnt -1 or
       scopes.indexOf('punctuation.definition.tag.end.html') isnt -1
 
-  isAttributeValueStartWithNoPrefix: ({scopeDescriptor, prefix}) ->
+  isAttributeValueStartWithNoPrefix: ({scopeDescriptor, prefix, bufferPosition, editor}) ->
     lastPrefixCharacter = prefix[prefix.length - 1]
     return false unless lastPrefixCharacter in ['"', "'"]
+
     scopes = scopeDescriptor.getScopesArray()
-    @hasStringScope(scopes) and @hasTagScope(scopes)
+
+    previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - 1)]
+    previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
+    previousScopesArray = previousScopes.getScopesArray()
+
+    @hasStringScope(scopes) and
+      (scopes.indexOf('punctuation.definition.string.end.html') is -1 or
+      previousScopesArray.indexOf('punctuation.definition.string.begin.html') isnt -1) and
+      @hasTagScope(scopes)
 
   isAttributeValueStartWithPrefix: ({scopeDescriptor, prefix}) ->
+    return false unless prefix
     lastPrefixCharacter = prefix[prefix.length - 1]
     return false if lastPrefixCharacter in ['"', "'"]
     scopes = scopeDescriptor.getScopesArray()
-    @hasStringScope(scopes) and @hasTagScope(scopes)
+    @hasStringScope(scopes) and
+      scopes.indexOf('punctuation.definition.string.begin.html') is -1 and
+      @hasTagScope(scopes)
 
   hasTagScope: (scopes) ->
     scopes.indexOf('meta.tag.any.html') isnt -1 or

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -231,6 +231,22 @@ describe "HTML autocompletions", ->
     expect(-> completions = getCompletions()).not.toThrow()
     expect(completions[0].displayText).toBe 'onafterprint'
 
+  it "does not attempt to autocomplete values before the beginning of a string", ->
+    editor.setText('<button type=""')
+    editor.setCursorBufferPosition([0, 13])
+
+    completions = []
+    expect(-> completions = getCompletions()).not.toThrow()
+    expect(completions.length).toBe 0
+
+  it "does not attempt to autocomplete values after the end of a string", ->
+    editor.setText('<button type=""')
+    editor.setCursorBufferPosition([0, 15])
+
+    completions = []
+    expect(-> completions = getCompletions()).not.toThrow()
+    expect(completions.length).toBe 0
+
   it "does not provide a descriptionMoreURL if the attribute does not have a unique description", ->
     editor.setText('<input on')
     editor.setCursorBufferPosition([0, 9])


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Another fix to prevent accessing undefined attribute options.  The logic for determining if a value was being autocompleted didn't take into account that the string scope is still valid one character before and after the actual string.  Also, `isAttributeValueStartWithPrefix` could potentially return true even if there was no prefix.

### Alternate Designs

An existence check could be added when attempting to access the attribute options.  However, that's just papering over the real problem (that we shouldn't even be trying to be autocompleting anything).

### Benefits

Less uncaught exceptions.

### Possible Drawbacks

Pretty sure none.

### Applicable Issues

None.