### PR TITLE
More fixes to attribute value autocompletion

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -74,9 +74,10 @@ module.exports =
     previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
     previousScopesArray = previousScopes.getScopesArray()
 
-    # autocomplete here: "|"
-    # not here: |""
-    # or here: ""|
+    # autocomplete here: attribute="|"
+    # not here: attribute=|""
+    # or here: attribute=""|
+    # or here: attribute="""|
     @hasStringScope(scopes) and @hasStringScope(previousScopesArray) and
       previousScopesArray.indexOf('punctuation.definition.string.end.html') is -1 and
       @hasTagScope(scopes) and
@@ -141,7 +142,7 @@ module.exports =
     for value in values when not prefix or firstCharsEqual(value, prefix)
       completions.push(@buildAttributeValueCompletion(tag, attribute, value))
 
-    if completions.length is 0 and @completions.attributes[attribute].type is 'boolean'
+    if completions.length is 0 and @completions.attributes[attribute]?.type is 'boolean'
       completions.push(@buildAttributeValueCompletion(tag, attribute, 'true'))
       completions.push(@buildAttributeValueCompletion(tag, attribute, 'false'))
 

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -79,7 +79,8 @@ module.exports =
     # or here: ""|
     @hasStringScope(scopes) and @hasStringScope(previousScopesArray) and
       previousScopesArray.indexOf('punctuation.definition.string.end.html') is -1 and
-      @hasTagScope(scopes)
+      @hasTagScope(scopes) and
+      @getPreviousAttribute(editor, bufferPosition)?
 
   hasTagScope: (scopes) ->
     scopes.indexOf('meta.tag.any.html') isnt -1 or

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -137,7 +137,7 @@ module.exports =
     tag = @getPreviousTag(editor, bufferPosition)
     attribute = @getPreviousAttribute(editor, bufferPosition)
     values = @getAttributeValues(tag, attribute)
-    for value in values when not prefix or firstCharsEqual(value, prefix) or prefix.endsWith('"') or prefix.endsWith("'")
+    for value in values when not prefix or firstCharsEqual(value, prefix)
       completions.push(@buildAttributeValueCompletion(tag, attribute, value))
 
     if completions.length is 0 and @completions.attributes[attribute].type is 'boolean'

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -133,12 +133,11 @@ module.exports =
     descriptionMoreURL: if description then @getGlobalAttributeDocsURL(attribute) else null
 
   getAttributeValueCompletions: ({prefix, editor, bufferPosition}) ->
-    prefix = undefined if prefix.endsWith('"') or prefix.endsWith("'")
     completions = []
     tag = @getPreviousTag(editor, bufferPosition)
     attribute = @getPreviousAttribute(editor, bufferPosition)
     values = @getAttributeValues(tag, attribute)
-    for value in values when not prefix or firstCharsEqual(value, prefix)
+    for value in values when not prefix or firstCharsEqual(value, prefix) or prefix.endsWith('"') or prefix.endsWith("'")
       completions.push(@buildAttributeValueCompletion(tag, attribute, value))
 
     if completions.length is 0 and @completions.attributes[attribute].type is 'boolean'

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -168,14 +168,15 @@ module.exports =
     return
 
   getPreviousAttribute: (editor, bufferPosition) ->
-    line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition]).trim()
-
     # Remove everything until the opening quote
-    quoteIndex = line.length - 1
-    quoteIndex-- while line[quoteIndex] and not (line[quoteIndex] in ['"', "'"])
-    line = line.substring(0, quoteIndex)
+    quoteIndex = bufferPosition.column - 1 # Don't start at the end of the line
+    while quoteIndex
+      scopes = editor.scopeDescriptorForBufferPosition([bufferPosition.row, quoteIndex])
+      scopesArray = scopes.getScopesArray()
+      break if scopesArray.indexOf('punctuation.definition.string.begin.html') isnt -1
+      quoteIndex--
 
-    attributePattern.exec(line)?[1]
+    attributePattern.exec(editor.getTextInRange([[bufferPosition.row, 0], [bufferPosition.row, quoteIndex]]))?[1]
 
   getAttributeValues: (tag, attribute) ->
     # Some local attributes are valid for multiple tags but have different attribute values

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -6,6 +6,10 @@ describe "HTML autocompletions", ->
     start = cursor.getBeginningOfCurrentWordBufferPosition()
     end = cursor.getBufferPosition()
     prefix = editor.getTextInRange([start, end])
+    # The above implementation is a simplified version of what ac+ uses and
+    # is incorrect for attribute values. Fix the prefix when that happens
+    # so that we're testing actual scenarios
+    prefix = '' if prefix.startsWith('="') or prefix.startsWith("='")
     request =
       editor: editor
       bufferPosition: end
@@ -231,22 +235,6 @@ describe "HTML autocompletions", ->
     expect(-> completions = getCompletions()).not.toThrow()
     expect(completions[0].displayText).toBe 'onafterprint'
 
-  it "does not attempt to autocomplete values before the beginning of a string", ->
-    editor.setText('<button type=""')
-    editor.setCursorBufferPosition([0, 13])
-
-    completions = []
-    expect(-> completions = getCompletions()).not.toThrow()
-    expect(completions.length).toBe 0
-
-  it "does not attempt to autocomplete values after the end of a string", ->
-    editor.setText('<button type=""')
-    editor.setCursorBufferPosition([0, 15])
-
-    completions = []
-    expect(-> completions = getCompletions()).not.toThrow()
-    expect(completions.length).toBe 0
-
   it "does not provide a descriptionMoreURL if the attribute does not have a unique description", ->
     editor.setText('<input on')
     editor.setCursorBufferPosition([0, 9])
@@ -375,6 +363,22 @@ describe "HTML autocompletions", ->
     expect(completions.length).toBe 2
     expect(completions[0].text).toBe 'true'
     expect(completions[1].text).toBe 'false'
+
+  it "does not attempt to autocomplete values before the beginning of a string", ->
+    editor.setText('<button type=""')
+    editor.setCursorBufferPosition([0, 13])
+
+    completions = []
+    expect(-> completions = getCompletions()).not.toThrow()
+    expect(completions.length).toBe 0
+
+  it "does not attempt to autocomplete values after the end of a string", ->
+    editor.setText('<button type=""')
+    editor.setCursorBufferPosition([0, 15])
+
+    completions = []
+    expect(-> completions = getCompletions()).not.toThrow()
+    expect(completions.length).toBe 0
 
   it "triggers autocomplete when an attibute has been inserted", ->
     spyOn(atom.commands, 'dispatch')

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -394,6 +394,14 @@ describe "HTML autocompletions", ->
     expect(-> completions = getCompletions()).not.toThrow()
     expect(completions.length).toBe 0
 
+  it "does not throw when attempting to autocomplete values for nonexistent attributes", ->
+    editor.setText('<button typ=""')
+    editor.setCursorBufferPosition([0, 13])
+
+    completions = []
+    expect(-> completions = getCompletions()).not.toThrow()
+    expect(completions.length).toBe 0
+
   it "triggers autocomplete when an attibute has been inserted", ->
     spyOn(atom.commands, 'dispatch')
     suggestion = {type: 'attribute', text: 'whatever'}

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -380,6 +380,12 @@ describe "HTML autocompletions", ->
     expect(-> completions = getCompletions()).not.toThrow()
     expect(completions.length).toBe 0
 
+  it "does not throw when quotes are in the attribute value", ->
+    editor.setText('<button type="\'"')
+    editor.setCursorBufferPosition([0, 15])
+
+    expect(-> completions = getCompletions()).not.toThrow()
+
   it "triggers autocomplete when an attibute has been inserted", ->
     spyOn(atom.commands, 'dispatch')
     suggestion = {type: 'attribute', text: 'whatever'}

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -386,6 +386,14 @@ describe "HTML autocompletions", ->
 
     expect(-> completions = getCompletions()).not.toThrow()
 
+  it "does not autocomplete attribute values if there isn't a corresponding attribute", ->
+    editor.setText('<button type="""')
+    editor.setCursorBufferPosition([0, 16])
+
+    completions = []
+    expect(-> completions = getCompletions()).not.toThrow()
+    expect(completions.length).toBe 0
+
   it "triggers autocomplete when an attibute has been inserted", ->
     spyOn(atom.commands, 'dispatch')
     suggestion = {type: 'attribute', text: 'whatever'}


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Hopefully this will be the last batch of fixes.  #62 caused value autocompletion to stop working entirely.  Specs didn't catch it for some reason (probably because of a different prefix being sent).  I'll try to tweak the specs so that they cover more real-life scenarios and do some extra testing to make sure everything's working as expected.

### Alternate Designs

Instead of manually adjusting the prefix in the specs, the specs could call the internal method that ac+ uses to get the actual prefix.

### Benefits

Value autocompletion will work again.

### Possible Drawbacks

Regressions.  I'll be testing this more though.

### Applicable Issues

None.