### PR TITLE
Consolidate methods with prefix variants

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -2,7 +2,6 @@ COMPLETIONS = require '../completions.json'
 
 attributePattern = /\s+([a-zA-Z][-a-zA-Z]*)\s*=\s*$/
 tagPattern = /<([a-zA-Z][-a-zA-Z]*)(?:\s|$)/
-tagStartPattern = /<\s*$/
 
 module.exports =
   selector: '.text.html'
@@ -30,12 +29,12 @@ module.exports =
     return @hasTagScope(scopeDescriptor.getScopesArray()) if prefix.trim() and prefix.indexOf('<') is -1
 
     # autocomplete-plus's default prefix setting does not capture <. Manually check for it.
-    prefix = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+    prefix = editor.getTextInRange([[bufferPosition.row, bufferPosition.column - 1], bufferPosition])
 
     scopes = scopeDescriptor.getScopesArray()
 
     # Don't autocomplete in embedded languages
-    tagStartPattern.test(prefix) and scopes[0] is 'text.html.basic' and scopes.length is 1
+    prefix is '<' and scopes[0] is 'text.html.basic' and scopes.length is 1
 
   isAttributeStart: ({prefix, scopeDescriptor, bufferPosition, editor}) ->
     scopes = scopeDescriptor.getScopesArray()
@@ -82,7 +81,7 @@ module.exports =
 
   getTagNameCompletions: ({prefix, editor, bufferPosition}) ->
     # autocomplete-plus's default prefix setting does not capture <. Manually check for it.
-    ignorePrefix = tagStartPattern.test(editor.getTextInRange([[bufferPosition.row, 0], bufferPosition]))
+    ignorePrefix = editor.getTextInRange([[bufferPosition.row, bufferPosition.column - 1], bufferPosition]) is '<'
 
     completions = []
     for tag, options of @completions.tags when ignorePrefix or firstCharsEqual(tag, prefix)

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -45,12 +45,13 @@ module.exports =
     previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
     previousScopesArray = previousScopes.getScopesArray()
 
-    return true if scopes.indexOf('entity.other.attribute-name.html') isnt -1 or
-      previousScopesArray.indexOf('entity.other.attribute-name.html') isnt -1
+    return true if previousScopesArray.indexOf('entity.other.attribute-name.html') isnt -1
     return false unless @hasTagScope(scopes)
 
-    scopes.indexOf('punctuation.definition.tag.html') isnt -1 or
-      scopes.indexOf('punctuation.definition.tag.end.html') isnt -1
+    # autocomplete here: <tag |>
+    # not here: <tag >|
+    scopes.indexOf('punctuation.definition.tag.end.html') isnt -1 and
+      previousScopesArray.indexOf('punctuation.definition.tag.end.html') is -1
 
   isAttributeValueStart: ({scopeDescriptor, bufferPosition, editor}) ->
     scopes = scopeDescriptor.getScopesArray()

--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -39,7 +39,7 @@ module.exports =
 
   isAttributeStart: ({prefix, scopeDescriptor, bufferPosition, editor}) ->
     scopes = scopeDescriptor.getScopesArray()
-    return @hasTagScope(scopes) if prefix and not prefix.trim()
+    return @hasTagScope(scopes) if not @getPreviousAttribute(editor, bufferPosition) and prefix and not prefix.trim()
 
     previousBufferPosition = [bufferPosition.row, Math.max(0, bufferPosition.column - 1)]
     previousScopes = editor.scopeDescriptorForBufferPosition(previousBufferPosition)
@@ -159,12 +159,12 @@ module.exports =
     return
 
   getPreviousAttribute: (editor, bufferPosition) ->
-    # Remove everything until the opening quote
+    # Remove everything until the opening quote (if we're in a string)
     quoteIndex = bufferPosition.column - 1 # Don't start at the end of the line
     while quoteIndex
       scopes = editor.scopeDescriptorForBufferPosition([bufferPosition.row, quoteIndex])
       scopesArray = scopes.getScopesArray()
-      break if scopesArray.indexOf('punctuation.definition.string.begin.html') isnt -1
+      break if not @hasStringScope(scopesArray) or scopesArray.indexOf('punctuation.definition.string.begin.html') isnt -1
       quoteIndex--
 
     attributePattern.exec(editor.getTextInRange([[bufferPosition.row, 0], [bufferPosition.row, quoteIndex]]))?[1]

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -3,16 +3,13 @@ describe "HTML autocompletions", ->
 
   getCompletions = ->
     cursor = editor.getLastCursor()
-    start = cursor.getBeginningOfCurrentWordBufferPosition()
-    end = cursor.getBufferPosition()
-    prefix = editor.getTextInRange([start, end])
-    # The above implementation is a simplified version of what ac+ uses and
-    # is incorrect for attribute values. Fix the prefix when that happens
-    # so that we're testing actual scenarios
-    prefix = '' if prefix.startsWith('="') or prefix.startsWith("='")
+    bufferPosition = cursor.getBufferPosition()
+    line = editor.getTextInRange([[bufferPosition.row, 0], bufferPosition])
+    # https://github.com/atom/autocomplete-plus/blob/9506a5c5fafca29003c59566cfc2b3ac37080973/lib/autocomplete-manager.js#L57
+    prefix = /(\b|['"~`!@#$%^&*(){}[\]=+,/?>])((\w+[\w-]*)|([.:;[{(< ]+))$/.exec(line)?[2] ? ''
     request =
       editor: editor
-      bufferPosition: end
+      bufferPosition: bufferPosition
       scopeDescriptor: cursor.getScopeDescriptor()
       prefix: prefix
     provider.getSuggestions(request)

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -237,6 +237,31 @@ describe "HTML autocompletions", ->
     completions = getCompletions()
     expect(completions[0].snippet).toBe 'autofocus'
 
+  it "does not autocomplete attribute names in between an attribute name and value", ->
+    editor.setText('<select autofocus=""')
+    editor.setCursorBufferPosition([0, 18])
+
+    completions = getCompletions()
+    expect(completions.length).toBe 0
+
+    editor.setText('<select autofocus= ""')
+    editor.setCursorBufferPosition([0, 18])
+
+    completions = getCompletions()
+    expect(completions.length).toBe 0
+
+    editor.setText('<select autofocus= ""')
+    editor.setCursorBufferPosition([0, 19])
+
+    completions = getCompletions()
+    expect(completions.length).toBe 0
+
+    editor.setText('<select autofocus=  ""')
+    editor.setCursorBufferPosition([0, 19])
+
+    completions = getCompletions()
+    expect(completions.length).toBe 0
+
   it "does not autocomplete attribute names outside of a tag", ->
     editor.setText('<kbd>')
     editor.setCursorBufferPosition([0, 0])

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -103,6 +103,19 @@ describe "HTML autocompletions", ->
     expect(completions[7].text).toBe 'dl'
     expect(completions[8].text).toBe 'dt'
 
+  it "does not autocomplete tag names if there's a space after the <", ->
+    editor.setText('< ')
+    editor.setCursorBufferPosition([0, 2])
+
+    completions = getCompletions()
+    expect(completions.length).toBe 0
+
+    editor.setText('< h')
+    editor.setCursorBufferPosition([0, 2])
+
+    completions = getCompletions()
+    expect(completions.length).toBe 0
+
   it "does not provide a descriptionMoreURL if the tag does not have a unique description", ->
     # ilayer does not have an associated MDN page as of April 27, 2017
     editor.setText('<i')

--- a/spec/provider-spec.coffee
+++ b/spec/provider-spec.coffee
@@ -143,6 +143,20 @@ describe "HTML autocompletions", ->
       expect(completion.description.length).toBeGreaterThan 0
       expect(completion.type).toBe 'attribute'
 
+    editor.setText('<div >')
+    editor.setCursorBufferPosition([0, 5])
+
+    completions = getCompletions()
+    expect(completions.length).toBeGreaterThan 0
+    expect(completion.type).toBe 'attribute' for completion in completions
+
+    editor.setText('<div  >')
+    editor.setCursorBufferPosition([0, 5])
+
+    completions = getCompletions()
+    expect(completions.length).toBeGreaterThan 0
+    expect(completion.type).toBe 'attribute' for completion in completions
+
   it "autocompletes attribute names with a prefix", ->
     editor.setText('<div c')
     editor.setCursorBufferPosition([0, 6])
@@ -222,6 +236,16 @@ describe "HTML autocompletions", ->
 
     completions = getCompletions()
     expect(completions[0].snippet).toBe 'autofocus'
+
+  it "does not autocomplete attribute names outside of a tag", ->
+    editor.setText('<kbd>')
+    editor.setCursorBufferPosition([0, 0])
+
+    expect(getCompletions().length).toBe 0
+
+    editor.setCursorBufferPosition([0, 5])
+
+    expect(getCompletions().length).toBe 0
 
   it "does not throw when a local attribute is not in the attributes list", ->
     # Some tags, like body, have local attributes that are not present in the top-level attributes array


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

I realized in #63 that it really isn't necessary to have separate code paths depending on whether or not there's a prefix.  Therefore I've combined all of them.

Testing this manually and with specs made me realize two things regarding the prefix:
1. `<` is considered a prefix if and only if extended unicode support is enabled in autocomplete-plus's settings
2. Instead of adding mini-hacks to try to get the right prefix in the specs, just copy/paste the actual ac+ implementation

`isTagStartWithNoPrefix` was previously checking for the existence of `meta.scope.outside-tag.html`.  That no longer exists.

### Alternate Designs

None

### Benefits

Hopefully this should make the flow easier to follow.

### Possible Drawbacks

I consider this a refactor, so regressions are a real possibility.  I've been improving the test coverage over the last few days though so hopefully it's robust enough now to catch most regressions.

### Applicable Issues

None