### PR TITLE
GlobalEventHandlers have different docs URL on mdn then attribute

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -181,7 +181,10 @@ module.exports =
     "#{@getTagDocsURL(tag)}#attr-#{attribute}"
 
   getGlobalAttributeDocsURL: (attribute) ->
-    "https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/#{attribute}"
+    if attribute.startsWith('on')
+      "https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/#{attribute}"
+    else
+      "https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/#{attribute}"    
 
 firstCharsEqual = (str1, str2) ->
   str1[0].toLowerCase() is str2[0].toLowerCase()


### PR DESCRIPTION
getGlobalAtributeDocsURL function in lib/provider.coffee was returning 
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/{attributename} for all attributes,
but Events like onlick, onselect have different URL on mdn
https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/{eventname}.

That's why I filtered the return value of this function depending on attribute name, 
if attribute starts with "on" which means  an event
then doc URL will be https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/{eventname}
else
same as it were before.