### PR TITLE
issue-74: Get first the attribute/value completions

### DIFF
--- a/lib/provider.coffee
+++ b/lib/provider.coffee
@@ -169,7 +169,7 @@ module.exports =
   getAttributeValues: (tag, attribute) ->
     # Some local attributes are valid for multiple tags but have different attribute values
     # To differentiate them, they are identified in the completions file as tag/attribute
-    @completions.attributes[attribute]?.attribOption ? @completions.attributes["#{tag}/#{attribute}"]?.attribOption ? []
+    @completions.attributes["#{tag}/#{attribute}"]?.attribOption ? @completions.attributes[attribute]?.attribOption ? []
 
   getTagAttributes: (tag) ->
     @completions.tags[tag]?.attributes ? []


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The options have to be selected by `tag/attribute` first because as says the comment in `getAttributeValues`:

>     # Some local attributes are valid for multiple tags but have different attribute values
>     # To differentiate them, they are identified in the completions file as tag/attribute

In #74 they reported that the `rel` attribute was not showing the `stylesheet` option. The problem was that the options given were for `rel` and not for `link/rel`.

 I noticed that mistake doing a `console.log` of the returned values. First I `console.log` inside the method (mentioned before) the values returned by `@completions.attributes["#{tag}/#{attribute}"]?.attribOption` and the result was the expected, an `array` of length 13.

Then I `console.log` the values after get them and I saw that the values an `array` of length 14:

`["alternate", "author", "bookmark", "help", "license", "next", "nofollow", "noreferrer", "prefetch", "prev", "search", "sidebar", "tag", "external"]`

The result that was given it was for `rel` instead of `link/rel`.

### Alternate Designs

None.

### Benefits

It will display the correct suggestions for `tag/attributes`

### Possible Drawbacks

None.

### Applicable Issues
Fixes #74 and other suggestions for `tag/attributes` 
