### PR TITLE
Fix error when editing EJS w/ tree-sitter

### DIFF
--- a/lib/tree-sitter-provider.js
+++ b/lib/tree-sitter-provider.js
@@ -69,7 +69,10 @@ module.exports = function ({editor, bufferPosition}) {
 
 function tokenBeforePosition (editor, position) {
   const languageMode = editor.getBuffer().getLanguageMode()
-  let node = languageMode.getSyntaxNodeAtPosition(position)
+  let node = languageMode.getSyntaxNodeAtPosition(
+    position,
+    (node, grammar) => grammar.scopeName === 'text.html.basic'
+  )
   if (!node) return null
   node = lastDescendant(node)
 

--- a/spec/provider-spec.js
+++ b/spec/provider-spec.js
@@ -501,4 +501,21 @@ describe('HTML autocompletions', () => {
     expect(args[0].tagName.toLowerCase()).toBe('atom-text-editor')
     expect(args[1]).toBe('autocomplete-plus:activate')
   })
+
+  it('does not error in EJS documents', () => {
+    waitsForPromise(async () => {
+      await atom.workspace.open('test.html.ejs')
+      editor = atom.workspace.getActiveTextEditor()
+      editor.setText('<span><% a = ""; %></span>')
+    })
+
+    waitsForPromise(() => {
+      return atom.packages.activatePackage('language-javascript')
+    })
+
+    runs(() => {
+      editor.setCursorBufferPosition([0, editor.getText().indexOf('""') + 1])
+      expect(() => getCompletions()).not.toThrow()
+    })
+  })
 })


### PR DESCRIPTION
This fixes an exception that I came across when editing an EJS file. When querying for syntax nodes, we need to make sure we're getting a node from the HTML syntax tree, not the JavaScript syntax tree.